### PR TITLE
Ignore double colon suffixes ::smth

### DIFF
--- a/src/main/java/com/axiomalaska/jdbc/NamedParameterPreparedStatement.java
+++ b/src/main/java/com/axiomalaska/jdbc/NamedParameterPreparedStatement.java
@@ -57,6 +57,7 @@ public class NamedParameterPreparedStatement extends DelegatingPreparedStatement
         boolean inDoubleQuote = false;
         boolean inSingleLineComment = false;
         boolean inMultiLineComment = false;
+        boolean inDoubleСolon = false;
 
         for (int i = 0; i < length; i++) {
             char c = query.charAt(i);
@@ -72,6 +73,10 @@ public class NamedParameterPreparedStatement extends DelegatingPreparedStatement
                 if (c == '*' && query.charAt(i + 1) == '/') {
                     inMultiLineComment = false;
                 }
+            } else if (inDoubleСolon) {
+            	if (!Character.isJavaIdentifierPart(c)) {
+            		inDoubleСolon = false;
+                }
             } else if (inSingleLineComment) {
                 if (c == '\n') {
                     inSingleLineComment = false;
@@ -85,6 +90,8 @@ public class NamedParameterPreparedStatement extends DelegatingPreparedStatement
                     inMultiLineComment = true;
                 } else if (c == '-' && query.charAt(i + 1) == '-') {
                     inSingleLineComment = true;
+                } else if (c == ':' && query.charAt(i + 1) == ':') {
+                	inDoubleСolon = true;    
                 } else if (c == ':' && i + 1 < length && Character.isJavaIdentifierStart(query.charAt(i + 1))) {
                     int j = i + 2;
                     while (j < length && Character.isJavaIdentifierPart(query.charAt(j))) {

--- a/src/test/java/com/axiomalaska/jdbc/TestNamedParameterPreparedStatement.java
+++ b/src/test/java/com/axiomalaska/jdbc/TestNamedParameterPreparedStatement.java
@@ -35,4 +35,14 @@ public class TestNamedParameterPreparedStatement {
         assertEquals(expectedParsedQuery, parseResult.getSql());
         assertThat(expectedParameterList, is(parseResult.getOrderedParameters()));
     }
+
+    @Test
+    public void testDoubleColon() throws IOException{
+        String testQuery = "SELECT '{1,2,3,4,5}'::int[] WHERE some_field = :some_field_value";
+        String expectedParsedQuery = "SELECT '{1,2,3,4,5}'::int[] WHERE some_field = ?";
+        List<String> expectedParameterList = Lists.newArrayList("some_field_value");
+        ParseResult parseResult = NamedParameterPreparedStatement.parse(testQuery);
+        assertEquals(expectedParsedQuery, parseResult.getSql());
+        assertThat(expectedParameterList, is(parseResult.getOrderedParameters()));
+    }
 }


### PR DESCRIPTION
In postgresql `::` used for type casting. Previous version parsed `select '{"a":"b"}::json'` with `::json` as parameter.
This patch ignores identifiers after double colon.