### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <licenses>
@@ -47,15 +49,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.0-jre</version>
+      <version>26.0-jre</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -65,7 +67,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -78,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -91,7 +93,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.1.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -104,7 +106,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/src/test/java/com/axiomalaska/jdbc/TestNamedParameterPreparedStatement.java
+++ b/src/test/java/com/axiomalaska/jdbc/TestNamedParameterPreparedStatement.java
@@ -1,19 +1,14 @@
 package com.axiomalaska.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import com.axiomalaska.jdbc.NamedParameterPreparedStatement.ParseResult;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.hamcrest.core.Is.is;
-
-import org.junit.Test;
-
-import com.axiomalaska.jdbc.NamedParameterPreparedStatement;
-import com.axiomalaska.jdbc.NamedParameterPreparedStatement.ParseResult;
-import com.google.common.collect.Lists;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestNamedParameterPreparedStatement {
     @Test
@@ -23,7 +18,7 @@ public class TestNamedParameterPreparedStatement {
         List<String> expectedParameterList = Lists.newArrayList("param1", "param2", "param2");
         ParseResult parseResult = NamedParameterPreparedStatement.parse(testQuery);
         assertEquals(expectedParsedQuery, parseResult.getSql());
-        assertThat(expectedParameterList, is(parseResult.getOrderedParameters()));
+        assertEquals(expectedParameterList, parseResult.getOrderedParameters());
     }
 
     @Test
@@ -33,7 +28,7 @@ public class TestNamedParameterPreparedStatement {
         List<String> expectedParameterList = Lists.newArrayList("named_parameter1", "named_parameter2");
         ParseResult parseResult = NamedParameterPreparedStatement.parse(testQuery);
         assertEquals(expectedParsedQuery, parseResult.getSql());
-        assertThat(expectedParameterList, is(parseResult.getOrderedParameters()));
+        assertEquals(expectedParameterList, parseResult.getOrderedParameters());
     }
 
     @Test
@@ -43,6 +38,6 @@ public class TestNamedParameterPreparedStatement {
         List<String> expectedParameterList = Lists.newArrayList("some_field_value");
         ParseResult parseResult = NamedParameterPreparedStatement.parse(testQuery);
         assertEquals(expectedParsedQuery, parseResult.getSql());
-        assertThat(expectedParameterList, is(parseResult.getOrderedParameters()));
+        assertEquals(expectedParameterList, parseResult.getOrderedParameters());
     }
 }


### PR DESCRIPTION
* JUnit 5 instead of 4
* Tests use new JUnit 5 API
  * Remove dependency on Hamcrest, assertEquals() is basically the same as assertThat(..., is(...))
* Update build plugin versions
* Sets compiler source & target to version 1.6 as there is code that will not work on earlier versions of Java